### PR TITLE
Fix: add missing dependency for PyYAML

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,6 +173,7 @@ setup(
     ##
     install_requires=[
         'python-mpd2',
+        'PyYAML',
     ],
 
     ##  extra package dependencies;


### PR DESCRIPTION
ncmpy imports the module `yaml` which is provided by dependency PyYAML;
however, `setup.py` didn't list it as a dependency which caused a
`ModuleNotFoundError`.